### PR TITLE
Prevent tags layout shifting when selecting them

### DIFF
--- a/owmods_gui/frontend/src/components/main/mods/ModsTagChips.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/ModsTagChips.tsx
@@ -2,7 +2,7 @@ import { hooks } from "@commands";
 import { withStyledErrorBoundary } from "@components/common/StyledErrorBoundary";
 import { useGetTranslation } from "@hooks";
 import { DeleteRounded } from "@mui/icons-material";
-import { Chip, IconButton, Stack } from "@mui/material";
+import { Chip, Stack } from "@mui/material";
 import { memo, useCallback, useEffect, useRef } from "react";
 
 export interface ModsTagsChipsProps {

--- a/owmods_gui/frontend/src/components/main/mods/ModsTagChips.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/ModsTagChips.tsx
@@ -2,7 +2,7 @@ import { hooks } from "@commands";
 import { withStyledErrorBoundary } from "@components/common/StyledErrorBoundary";
 import { useGetTranslation } from "@hooks";
 import { DeleteRounded } from "@mui/icons-material";
-import { Chip, Stack } from "@mui/material";
+import { Chip, IconButton, Stack } from "@mui/material";
 import { memo, useCallback, useEffect, useRef } from "react";
 
 export interface ModsTagsChipsProps {
@@ -44,18 +44,31 @@ const ModsTagsChips = memo(function ModsTagsChips(props: ModsTagsChipsProps) {
     }, []);
 
     return (
-        <Stack
-            className="scroll-shadows"
-            sx={{
-                minHeight: "25px",
-                overflowX: "auto",
-                scrollbarWidth: "none",
-                "::-webkit-scrollbar": { display: "none" }
-            }}
-            direction="row"
-            ref={scrollRef}
-            gap={1}
-        >
+        <Stack direction="row" gap={1}>
+            <Stack
+                className="scroll-shadows"
+                sx={{
+                    minHeight: "25px",
+                    overflowX: "auto",
+                    scrollbarWidth: "none",
+                    "::-webkit-scrollbar": { display: "none" }
+                }}
+                direction="row"
+                ref={scrollRef}
+                gap={1}
+            >
+                {availableTags.map((t) => (
+                    <Chip
+                        label={t}
+                        key={t}
+                        onClick={() => onChipClicked(t)}
+                        size="small"
+                        color={tagIsSelected(props.selectedTags, t) ? "primary" : "default"}
+                        variant={tagIsSelected(props.selectedTags, t) ? "filled" : "filled"}
+                    />
+                ))}
+            </Stack>
+
             {selectedTags.length !== 0 && (
                 <Chip
                     icon={<DeleteRounded />}
@@ -66,15 +79,6 @@ const ModsTagsChips = memo(function ModsTagsChips(props: ModsTagsChipsProps) {
                     onClick={() => props.onTagsChanged([])}
                 />
             )}
-            {availableTags.map((t) => (
-                <Chip
-                    label={t}
-                    key={t}
-                    onClick={() => onChipClicked(t)}
-                    size="small"
-                    variant={tagIsSelected(props.selectedTags, t) ? "filled" : "outlined"}
-                />
-            ))}
         </Stack>
     );
 });


### PR DESCRIPTION
<!-- Which packages this PR affects -->
## Package(s)

- [X] GUI
- [ ] CLI
- [ ] Core
- [ ] None

Two things this solves:
The tags changing from filled to outlined made their width change ever so slightly, so I'm keeping the same variant and just changing the color instead.
But the worst part was that clear button showing on the left. I'm not making it show on the right, but outside the scroll area.

![image](https://github.com/ow-mods/ow-mod-man/assets/3955124/6fb7b0ac-c839-4a5f-84cd-27c83b9de5fc)

