### PR TITLE
Add GitHub Repo Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This is the monorepo for the new <a href="https://www.mobiusdigitalgames.com/out
   - [Raicuparta](https://github.com/Raicuparta)
   - [JohnCorby](https://github.com/JohnCorby)
   - [dgarroDC](https://github.com/dgarroDC)
+  - [MegaPiggy](https://github.com/MegaPiggy)
 - Testing:
   - [ShoosGun](https://github.com/ShoosGun)
   - [JohnCorby](https://github.com/JohnCorby)

--- a/owmods_cli/README.md
+++ b/owmods_cli/README.md
@@ -37,6 +37,7 @@ Some command shortcuts exist for convenience
 - `disable` -> `d`
 - `uninstall` -> `rm`
 - `readme` -> `man`
+- `github` -> `repo`
 
 ### Autocomplete
 

--- a/owmods_cli/src/cli.rs
+++ b/owmods_cli/src/cli.rs
@@ -193,6 +193,11 @@ pub enum Commands {
         #[arg(help = "The unique name of the mod to open the README of", value_hint = ValueHint::Other)]
         unique_name: String,
     },
+    #[command(about = "Open the github repo for a mod", alias = "repo")]
+    Github {
+        #[arg(help = "The unique name of the mod to open the GitHub repo of", value_hint = ValueHint::Other)]
+        unique_name: String,
+    },
     #[command(
         about = "Validate local mods for missing dependencies and conflicts",
         alias = "check"

--- a/owmods_cli/src/main.rs
+++ b/owmods_cli/src/main.rs
@@ -17,7 +17,7 @@ use owmods_core::{
         local::{LocalMod, UnsafeLocalMod},
         remote::RemoteMod,
     },
-    open::{open_readme, open_shortcut},
+    open::{open_github, open_readme, open_shortcut},
     remove::{remove_failed_mod, remove_mod},
     toggle::toggle_mod,
     updates::update_all,
@@ -421,6 +421,11 @@ async fn run_from_cli(cli: BaseCli) -> Result<()> {
             info!("Opening README for {}", unique_name);
             let remote_db = RemoteDatabase::fetch(&config.database_url).await?;
             open_readme(unique_name, &remote_db)?;
+        }
+        Commands::Github { unique_name } => {
+            info!("Opening GitHub repo for {}", unique_name);
+            let remote_db = RemoteDatabase::fetch(&config.database_url).await?;
+            open_github(unique_name, &remote_db)?;
         }
         Commands::Validate { fix } => {
             let mut local_db = LocalDatabase::fetch(&config.owml_path)?;

--- a/owmods_core/src/open.rs
+++ b/owmods_core/src/open.rs
@@ -54,3 +54,18 @@ pub fn open_readme(unique_name: &str, db: &RemoteDatabase) -> Result<()> {
     opener::open(format!("{WEBSITE_URL}/mods/{slug}/"))?;
     Ok(())
 }
+
+/// Open the github repo for a mod in the user's browser
+///
+/// ## Errors
+///
+/// If the unique name provided is not an installed mod or we can't open the browser.
+///
+pub fn open_github(unique_name: &str, db: &RemoteDatabase) -> Result<()> {
+    let remote_mod = db
+        .get_mod(unique_name)
+        .ok_or_else(|| anyhow!("Mod {} not found", unique_name))?;
+    let repo = &remote_mod.repo; // this is the entire link to the repo
+    opener::open(repo)?;
+    Ok(())
+}

--- a/owmods_gui/backend/src/commands.rs
+++ b/owmods_gui/backend/src/commands.rs
@@ -21,7 +21,7 @@ use owmods_core::{
     file::{create_all_parents, get_app_path},
     game::launch_game,
     mods::{local::UnsafeLocalMod, remote::RemoteMod},
-    open::{open_readme, open_shortcut},
+    open::{open_github, open_readme, open_shortcut},
     owml::OWMLConfig,
     remove::{remove_failed_mod, remove_mod},
     socket::{LogServer, SocketMessageType},
@@ -987,5 +987,12 @@ pub async fn get_db_tags(state: tauri::State<'_, State>) -> Result<Vec<String>> 
 #[tauri::command]
 pub async fn log_error(err: &str) -> Result {
     error!("Error Received From Frontend: {}", err);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn open_mod_github(unique_name: &str, state: tauri::State<'_, State>) -> Result {
+    let db = state.remote_db.read().await;
+    open_github(unique_name, &db)?;
     Ok(())
 }

--- a/owmods_gui/backend/src/main.rs
+++ b/owmods_gui/backend/src/main.rs
@@ -181,7 +181,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             log_error,
             get_bar_by_unique_name,
             register_drop_handler,
-            get_db_tags
+            get_db_tags,
+            open_mod_github
         ])
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .run(tauri::generate_context!())

--- a/owmods_gui/frontend/src/assets/translations/english.json
+++ b/owmods_gui/frontend/src/assets/translations/english.json
@@ -80,6 +80,7 @@
     "OPEN_OWML": "Show OWML Folder",
     "OPEN_README": "Show On Website",
     "OPEN_WEBSITE": "Browse Mods Website",
+    "OPEN_GITHUB": "More info on GitHub",
     "OUTDATED": "Outdated",
     "OWML_INSTALL_ERROR": "There was an error downloading OWML, please check your network connection and try again.",
     "OWML_NO_PRERELEASE": "There is no prerelease for OWML available",

--- a/owmods_gui/frontend/src/assets/translations/template.json
+++ b/owmods_gui/frontend/src/assets/translations/template.json
@@ -80,6 +80,7 @@
     "OPEN_OWML": "",
     "OPEN_README": "",
     "OPEN_WEBSITE": "",
+    "OPEN_GITHUB": "",
     "OUTDATED": "",
     "OWML_INSTALL_ERROR": "",
     "OWML_NO_PRERELEASE": "",

--- a/owmods_gui/frontend/src/commands.ts
+++ b/owmods_gui/frontend/src/commands.ts
@@ -45,6 +45,7 @@ const commandInfo = {
         ),
     toggleAll: $<CommandInfo<{ enabled: boolean }, string[]>>("toggle_all"),
     openModFolder: $<ModAction>("open_mod_folder"),
+    openModGithub: $<ModAction>("open_mod_github"),
     openModReadme: $<ModAction>("open_mod_readme"),
     openOwml: $<EmptyCommand>("open_owml"),
     uninstallMod: $<ModCommand<string[]>>("uninstall_mod"),

--- a/owmods_gui/frontend/src/components/main/mods/local/LocalModActions.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/local/LocalModActions.tsx
@@ -1,6 +1,7 @@
 import {
     DescriptionRounded,
     FolderRounded,
+    GitHub,
     DeleteRounded,
     ConstructionRounded
 } from "@mui/icons-material";
@@ -21,6 +22,7 @@ export interface LocalModActionsProps {
     onReadme: () => void;
     onFolder: () => void;
     onFix: () => void;
+    onGithub: () => void;
     onUninstall: () => void;
 }
 
@@ -71,6 +73,12 @@ const LocalModActions = memo(function LocalModTools(props: LocalModActionsProps)
                     label={getTranslation("SHOW_FOLDER")}
                     icon={<FolderRounded />}
                     onClick={props.onFolder}
+                    onClose={overflowRef.current?.onClose}
+                />
+                <ModActionOverflowItem
+                    label={getTranslation("OPEN_GITHUB")}
+                    icon={<GitHub />}
+                    onClick={props.onGithub}
                     onClose={overflowRef.current?.onClose}
                 />
                 <ModActionOverflowItem

--- a/owmods_gui/frontend/src/components/main/mods/local/LocalModRow.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/local/LocalModRow.tsx
@@ -94,6 +94,10 @@ const LocalModRow = memo(function LocalModRow(props: LocalModRowProps) {
         () => commands.openModFolder({ uniqueName: props.uniqueName }),
         [props.uniqueName]
     );
+    const onGithub = useCallback(
+        () => commands.openModGithub({ uniqueName: props.uniqueName }),
+        [props.uniqueName]
+    );
     const onToggle = useCallback(
         (newVal: boolean) => {
             const task = async () => {
@@ -163,6 +167,7 @@ const LocalModRow = memo(function LocalModRow(props: LocalModRowProps) {
                 onFix={onFix}
                 onFolder={onFolder}
                 onUninstall={onUninstall}
+                onGithub={onGithub}
             />
         ),
         [
@@ -175,7 +180,8 @@ const LocalModRow = memo(function LocalModRow(props: LocalModRowProps) {
             onReadme,
             onFix,
             onFolder,
-            onUninstall
+            onUninstall,
+            onGithub
         ]
     );
 

--- a/owmods_gui/frontend/src/components/main/mods/remote/RemoteModActions.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/remote/RemoteModActions.tsx
@@ -1,4 +1,4 @@
-import { DownloadRounded, DescriptionRounded, ScienceRounded } from "@mui/icons-material";
+import { DownloadRounded, DescriptionRounded, GitHub, ScienceRounded } from "@mui/icons-material";
 import { memo, useRef } from "react";
 import ModActionOverflow, { ModActionOverflowItem } from "../ModActionOverflow";
 import { useGetTranslation } from "@hooks";
@@ -11,6 +11,7 @@ export interface RemoteModActionsProps {
     prereleaseLabel: string;
     onInstall: () => void;
     onReadme: () => void;
+    onGithub: () => void;
     onPrerelease: () => void;
 }
 
@@ -31,6 +32,12 @@ const RemoteModActions = memo(function RemoteModToolbar(props: RemoteModActionsP
                     label={getTranslation("OPEN_README")}
                     icon={<DescriptionRounded />}
                     onClick={props.onReadme}
+                    onClose={overflowRef.current?.onClose}
+                />
+                <ModActionOverflowItem
+                    label={getTranslation("OPEN_GITHUB")}
+                    icon={<GitHub />}
+                    onClick={props.onGithub}
                     onClose={overflowRef.current?.onClose}
                 />
                 {props.showPrerelease && (

--- a/owmods_gui/frontend/src/components/main/mods/remote/RemoteModRow.tsx
+++ b/owmods_gui/frontend/src/components/main/mods/remote/RemoteModRow.tsx
@@ -54,6 +54,10 @@ const RemoteModRow = memo(function RemoteModRow(props: RemoteModRowProps) {
         commands.openModReadme({ uniqueName: props.uniqueName }).catch(simpleOnError);
     }, [props.uniqueName]);
 
+    const onGithub = useCallback(() => {
+        commands.openModGithub({ uniqueName: props.uniqueName }).catch(simpleOnError);
+    }, [props.uniqueName]);
+
     const modActions = useMemo(
         () => (
             <RemoteModActions
@@ -64,9 +68,19 @@ const RemoteModRow = memo(function RemoteModRow(props: RemoteModRowProps) {
                 onInstall={onInstall}
                 onPrerelease={onPrerelease}
                 onReadme={onReadme}
+                onGithub={onGithub}
             />
         ),
-        [busy, onInstall, onPrerelease, onReadme, prereleaseLabel, props.uniqueName, hasPrerelease]
+        [
+            busy,
+            onInstall,
+            onPrerelease,
+            onReadme,
+            onGithub,
+            prereleaseLabel,
+            props.uniqueName,
+            hasPrerelease
+        ]
     );
 
     return (


### PR DESCRIPTION
# Add GitHub Repo Button

<!-- Which packages this PR affects -->
## Package(s)

- [X] GUI
- [X] CLI
- [X] Core

<!-- Long description of what you changed -->
## Description
Added a github button to the mod actions. This button opens the repo of a mod in your browser.
It was also added as a command for the CLI.