### PR TITLE
Adding Nix Flake With Modules and Overlay

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,18 @@
 {
   "nodes": {
+    "flake-compat": {
+      "locked": {
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +49,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1698370541,
+        "narHash": "sha256-/mQQPmcRbpWsGgFi4vj4Bz2N2Yos4Vr+ru+v3qyEqp0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f1775e6477c6e342bbbdecf363f9f5821d7fd3e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,6 @@
   
   nixConfig = {
     extra-substituters = [ "https://ow-mods.cachix.org" ];
-    extra-trusted-public-keys = [ "ow-mods.cachix.org-1:0MHS+kc4aVTfKuMQ6hx2+JvHZEDukCscE8tYBou2+Ns=" ];
+    extra-trusted-public-keys = [ "ow-mods.cachix.org-1:6RTOd1dSRibA2W0MpZHxzT0tw1RzyhKObTPKQJpcrZo=" ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Flake for owmods-cli and owmods-gui";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+  };
+
+  outputs = { self, flake-utils, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = (import nixpkgs) {
+          inherit system;
+	  overlays = [ self.overlay.owmods ];
+        };
+      in rec {
+        # For `nix build` & `nix run`:
+        packages = rec {
+          owmods-cli = pkgs.owmods-cli;
+          owmods-gui = pkgs.owmods-gui;
+          default = pkgs.owmods-cli;
+        };        
+        # For `nix develop`:
+        #devShell = pkgs.mkShell {
+        #  nativeBuildInputs = with pkgs; [ rustc cargo openssl libsoup ];
+        #};
+      }
+    ) // {
+        overlay.owmods = import ./nix/overlay.nix;
+	nixosModules.owmods = import ./nix/modules/nixos.nix;
+	homeManagerModules.owmods = import ./nix/modules/hm.nix;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,4 +30,9 @@
 	nixosModules.owmods = import ./nix/modules/nixos.nix;
 	homeManagerModules.owmods = import ./nix/modules/hm.nix;
     };
+  
+  nixConfig = {
+    extra-substituters = [ "https://ow-mods.cachix.org" ];
+    extra-trusted-public-keys = [ "ow-mods.cachix.org-1:0MHS+kc4aVTfKuMQ6hx2+JvHZEDukCscE8tYBou2+Ns=" ];
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,11 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
     nixpkgs.url = "github:NixOS/nixpkgs/master";
   };
 
-  outputs = { self, flake-utils, nixpkgs }:
+  outputs = { self, flake-utils, flake-compat, nixpkgs }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = (import nixpkgs) {

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,97 @@
+# NixOS Installation
+
+You can either install using the package in [nixpkgs](https://search.nixos.org/packages?channel=unstable&show=owmods-cli&from=0&size=50&sort=relevance&type=packages&query=owmods) or by getting it from the flake.
+## Without Flakes
+
+This flake comes with [flake-compat](https://github.com/edolstra/flake-compat), which makes it usable in systems that use flakes, or not.
+
+To install it, edit you NixOS/Home Manager configuration with:
+```nix
+{ pkgs, lib, ... }:
+let
+  ow-mod-man = import (builtins.fetchGit {
+    url = "https://github.com/ow-mods/ow-mod-man.git";
+    # You can choose which version by changing the ref
+    ref = "dev";
+  });
+in
+{
+  imports = [
+    # For NixOS
+    ow-mod-man.nixosModules.owmods
+    # For Home Manager
+    ow-mod-man.homeManagerModules.owmods
+  ];
+  
+  # Unsafe dependency of the gui version
+  permittedInsecurePackages = [ "openssl-1.1.1w" ];
+
+  
+  # To enable the cli version
+  programs.owmods-cli.enable = true;
+  # To enable the gui version
+  programs.owmods-gui.enable = true;
+}
+```
+
+## Using Flakes
+
+If you are already using flakes, this is the recommended method, what you need to add is:
+
+- In your flake.nix:
+```nix
+{
+  inputs.ow-mod-man = {
+    url = "github:ow-mods/ow-mod-man/dev";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = { ow-mod-man }:
+  # You need to add the ow-mod-man overlay to your packages
+  let pkgs = import nixpkgs {
+      inherit system;
+      config = {
+        # Needed for the gui version
+        permittedInsecurePackages = [ "openssl-1.1.1w" ];
+      };
+      # Needed to be able to use the packages
+      overlays = [ ow-mod-man.overlay.owmods ];
+  };
+  in {
+      homeConfigurations = {
+      userA = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        # For your home.nix
+        modules = [ ow-mod-man.homeManagerModules.owmods ];
+      };
+    };
+
+    nixosConfigurations = {
+      systemA = lib.nixosSystem {
+        inherit system;
+        inherit pkgs;
+        # For your configuration.nix
+        modules = [ ow-mod-man.nixosModules.owmods ];
+      };
+  };
+}
+```
+- In your configuration.nix:
+```nix
+{ pkgs, inputs, ... }:
+{
+  # To enable the cli version
+  programs.owmods-cli.enable = true;
+  # To enable the gui version
+  programs.owmods-gui.enable = true;
+}
+```
+- In your home.nix:
+```nix
+{ pkgs, inputs, ... }:
+{
+  # To enable the cli version
+  programs.owmods-cli.enable = true;
+  # To enable the gui version
+  programs.owmods-gui.enable = true;
+}
+```

--- a/nix/modules/hm.nix
+++ b/nix/modules/hm.nix
@@ -1,0 +1,26 @@
+{ lib, pkgs, config, ... }:
+with lib;                      
+let
+  cli-cfg = config.programs.owmods-cli;
+  gui-cfg = config.programs.owmods-gui;
+in {
+  options.programs = {
+    owmods-cli = {
+      enable = mkEnableOption "owmods-cli program";
+    };
+    owmods-gui = {
+      enable = mkEnableOption "owmods-gui program";
+    };
+  };
+
+  config = mkIf (cli-cfg.enable || gui-cfg.enable) (
+  	mkMerge [{
+          home.packages = [
+            (mkIf cli-cfg.enable (pkgs.owmods-cli))
+            (mkIf gui-cfg.enable (pkgs.owmods-gui))
+	    pkgs.mono
+          ];
+	}]
+  );
+}
+

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,0 +1,26 @@
+{ lib, pkgs, config, ... }:
+with lib;                      
+let
+  cli-cfg = config.programs.owmods-cli;
+  gui-cfg = config.programs.owmods-gui;
+in {
+  options.programs = {
+    owmods-cli = {
+      enable = mkEnableOption "owmods-cli program";
+    };
+    owmods-gui = {
+      enable = mkEnableOption "owmods-gui program";
+    };
+  };
+
+  config = mkIf (cli-cfg.enable || gui-cfg.enable) (
+  	mkMerge [{
+          environment.systemPackages = [
+            (mkIf cli-cfg.enable (pkgs.owmods-cli))
+            (mkIf gui-cfg.enable (pkgs.owmods-gui))
+	    pkgs.mono
+          ];
+	}]
+  );
+}
+

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,4 @@
+final: prev: {
+  owmods-cli = final.pkgs.callPackage ./owmods-cli.nix {};
+  owmods-gui = final.pkgs.callPackage ./owmods-gui.nix {};
+}

--- a/nix/owmods-cli.nix
+++ b/nix/owmods-cli.nix
@@ -1,0 +1,48 @@
+{ lib
+, pkg-config
+, openssl
+, libsoup
+, fetchFromGitHub
+, installShellFiles
+, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "owmods-cli";
+  version = "0.11.3";
+
+  src = ../.;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    outputHashes = { "tauri-plugin-window-state-0.1.0" = "sha256-M6uGcf4UWAU+494wAK/r2ta1c3IZ07iaURLwJJR9F3U=";};
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    openssl
+    libsoup
+  ];
+
+  buildAndTestSubdir = "owmods_cli";
+
+  postInstall = ''
+    cargo xtask dist_cli
+    installManPage man/man*/*
+    installShellCompletion --cmd owmods \
+    dist/cli/completions/owmods.{bash,fish,zsh}
+  '';
+
+  meta = with lib; {
+    description = "CLI version of the mod manager for Outer Wilds Mod Loader";
+    homepage = "https://github.com/ow-mods/ow-mod-man/tree/main/owmods_cli";
+    downloadPage = "https://github.com/ow-mods/ow-mod-man/releases/tag/cli_v${version}";
+    changelog = "https://github.com/ow-mods/ow-mod-man/releases/tag/cli_v${version}";
+    mainProgram = "owmods";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ locochoco ];
+  };
+}

--- a/nix/owmods-gui.nix
+++ b/nix/owmods-gui.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, dpkg
+, fetchurl
+, autoPatchelfHook
+, glib-networking
+, openssl_1_1
+, webkitgtk
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "owmods-gui";
+  version = "0.11.3";
+
+  src = fetchurl {
+    url = "https://github.com/ow-mods/ow-mod-man/releases/download/gui_v${version}/outer-wilds-mod-manager_${version}_amd64.deb";
+    hash = "sha256-D+rnF40e1xpwKeMvyiOuhMSJ1+JlDKq5c195iam3d2Y=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+  ];
+
+  buildInputs = [
+    glib-networking
+    openssl_1_1
+    webkitgtk
+    wrapGAppsHook
+  ];
+
+  unpackCmd = "dpkg-deb -x $curSrc source";
+
+  installPhase = "mv usr $out";
+  meta = with lib; {
+    description = "GUI version of the mod manager for Outer Wilds Mod Loader";
+    homepage = "https://github.com/ow-mods/ow-mod-man/tree/main/owmods_gui";
+    downloadPage = "https://github.com/ow-mods/ow-mod-man/releases/tag/gui_v${version}";
+    changelog = "https://github.com/ow-mods/ow-mod-man/releases/tag/gui_v${version}";
+    mainProgram = "outer-wilds-mod-manager";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ locochoco ];
+  };
+}


### PR DESCRIPTION
# Adding Nix Flake With Modules and Overlay

<!-- Which packages this PR affects -->
## Package(s)

- [ ] GUI
- [ ] CLI
- [ ] Core
- [x] None

<!-- Any important notes (breaking API changes, etc) -->
<!-- If none, just delete the section -->
## Important Notes
Joins the [ow-mod-man-flake](https://github.com/ow-mods/ow-mod-man-flake) repo with this one.
<!-- Long description of what you changed -->
## Description
This PR is to move the nix flake from [ow-mod-man-flake](https://github.com/ow-mods/ow-mod-man-flake) to the root of the source code repository. With two new files are added to the root of the repo (flake.nix and flake.lock), and a folder called "nix", where the overlays, modules, and packages descriptions are kept.
This flake, in comparison to the one in [ow-mod-man-flake](https://github.com/ow-mods/ow-mod-man-flake), works much better with current systems running flakes, with modules for both nixosSystem and homeManger. Here is an example of usage of both modules:
```nix
# flake.nix
{  
  inputs = {
    #...
    ow-mod-man.url = "github:ow-mods/ow-mod-man/main";
    ow-mod-man.inputs.nixpkgs.follows = "nixpkgs";
    #...
    };
    outputs = { ..., ow-mod-man, ... }:
    let
    pkgs = import nixpkgs {
      inherit system;
      config = { 
	permittedInsecurePackages = [
	  #...
          "openssl-1.1.1w" #needed so owmods-gui can have its correct openssl version
          #...
        ];
      };

      overlays = [ ... ow-mod-man.overlay.owmods ...]; #needed so the modules can add the packages
    };
    in {
    homeConfigurations = {
      userA = home-manager.lib.homeManagerConfiguration {
        inherit pkgs;
        modules = [
          #...
	  ow-mod-man.homeManagerModules.owmods # if you want to call it in ./home.nix
          ./home.nix
	  #...
        ];
      };
    };

    nixosConfigurations = {
      systemA = lib.nixosSystem {
        inherit system;
        inherit pkgs;
        modules = [
          #...
          ow-mod-man.nixosModules.owmods # if you want to call it in ./configuration.nix
          ./configuration.nix
          #...
        ];
      };
  };
}
```
```nix
# home.nix
{ pkgs, inputs, ... }:
{
  #...
  programs.owmods-cli.enable = true; # to enable the cli
  programs.owmods-gui.enable = true; # to enable the gui
  #...
}
```

```nix
# configuration.nix
{ pkgs, inputs, ... }:
{
  #...
  programs.owmods-cli.enable = true; # to enable the cli
  programs.owmods-gui.enable = true; # to enable the gui
  #...
}
```