### PR TITLE
Update fix_deps to recursively fix all dependencies

### DIFF
--- a/owmods_core/src/validate.rs
+++ b/owmods_core/src/validate.rs
@@ -114,11 +114,7 @@ pub async fn fix_deps(
     queue.push_back(local_mod.clone());
 
     // Iterate over missing dependencies until no dependencies are left
-    loop {
-        if queue.is_empty() {
-            break;
-        }
-
+    while !queue.is_empty() {
         let mut missing: Vec<String> = vec![];
 
         while let Some(mod_to_check) = queue.pop_front() {


### PR DESCRIPTION
# Update fix_deps to recursively fix all dependencies

## Package(s)

- [ ] GUI
- [ ] CLI
- [x] Core
- [ ] None

## Description

This updates the `fix_deps` function in the `validate.rs` area of the core to recursively identify and resolve any missing dependencies. The implementation isn't actually recursive, but rather uses a `VecDeque` to store mods to be validated, starting with the mod provided as the parameter.